### PR TITLE
Fixed bug with multiprocessing and single loop over feature classes

### DIFF
--- a/hcga/feature_extraction.py
+++ b/hcga/feature_extraction.py
@@ -3,15 +3,17 @@ import multiprocessing
 import time
 from importlib import import_module
 from pathlib import Path
-
+import networkx as nx
 import numpy as np
 
 
-def extract(graphs, n_workers):
+def extract(graphs, n_workers, mode='fast'):
     """main function to extract features"""
 
-    all_features_raw = compute_all_features(graphs, n_workers=n_workers)
-    all_features, features_info_all = set_feature_ids(all_features_raw)
+    feat_classes = _get_list_feature_classes(mode)
+
+    all_features_raw = compute_all_features(graphs, feat_classes, n_workers=n_workers)
+    all_features, features_info_all = set_feature_ids(all_features_raw, feat_classes)
     feature_matrix, selected_ids = extract_feature_matrix(all_features)
     features_info = _relabel_feature_ids(features_info_all, selected_ids)
 
@@ -20,6 +22,24 @@ def extract(graphs, n_workers):
     )
 
     return feature_matrix, features_info
+
+def _get_list_feature_classes(mode='fast'):
+    """Generates and returns the list of feature classes to compute for a given mode"""
+    feature_path = Path(__file__).parent / "features"
+    non_feature_files = ["__init__", "feature_class"]
+
+    list_feature_classes = []
+    trivial_graph = nx.generators.classic.complete_graph(3)
+
+    for f_name in feature_path.glob("*.py"):
+        feature_name = f_name.stem
+        if feature_name not in non_feature_files:
+            feature_class = _load_feature_class(feature_name)
+            if mode in feature_class.modes:
+                list_feature_classes.append(feature_class)
+                # runs once update_feature with trivial graph to create class variables
+                feature_class(trivial_graph).update_features({})
+    return list_feature_classes
 
 
 def _relabel_feature_ids(features_info_all, selected_ids):
@@ -36,16 +56,16 @@ def _relabel_feature_ids(features_info_all, selected_ids):
 class Worker:
     """worker for computing features"""
 
-    def __init__(self, mode):
-        self.mode = mode
+    def __init__(self, list_feature_classes):
+        self.list_feature_classes = list_feature_classes
 
     def __call__(self, graph):
-        return feature_extraction(graph, self.mode)
+        return feature_extraction(graph, self.list_feature_classes)
 
 
-def compute_all_features(graphs, mode="fast", n_workers=1):
+def compute_all_features(graphs, list_feature_classes, n_workers=1):
     """compute the feature from all graphs"""
-    worker = Worker(mode)
+    worker = Worker(list_feature_classes)
     if n_workers == 1:
         mapper = map
     else:
@@ -55,69 +75,55 @@ def compute_all_features(graphs, mode="fast", n_workers=1):
     return list(mapper(worker, graphs))
 
 
-def _load_feature_class(feature_name, graph=None):
+def _load_feature_class(feature_name):
     """load the feature class from feature name"""
     feature_module = import_module("hcga.features." + feature_name)
-    return getattr(feature_module, feature_module.featureclass_name)(graph)
+    return getattr(feature_module, feature_module.featureclass_name)
 
 
-def feature_extraction(graph, mode="slow", with_runtimes=False):
+def feature_extraction(graph, list_feature_classes, with_runtimes=False):
     """extract features from a single graph"""
-    feature_path = Path(__file__).parent / "features"
-    non_feature_files = ["__init__", "feature_class"]
 
     if with_runtimes:
         runtimes = {}
 
     all_features = {}
-    for f_name in feature_path.glob("*.py"):
-        feature_name = f_name.stem
-        if feature_name not in non_feature_files:
+    for feature_class in list_feature_classes:
+        if with_runtimes:
+            start_time = time.time()
 
-            if with_runtimes:
-                start_time = time.time()
+        feature_inst = feature_class(graph)
+        feature_inst.update_features(all_features)
 
-            feature_class = _load_feature_class(feature_name, graph)
-            feature_class.update_features(all_features, mode)
-
-            if with_runtimes:
-                runtimes[feature_class.shortname] = time.time() - start_time
+        if with_runtimes:
+            runtimes[feature_class.shortname] = time.time() - start_time
 
     if with_runtimes:
         return all_features, runtimes
     return all_features
 
 
-def set_feature_ids(all_features_raw):
+def set_feature_ids(all_features_raw, list_feature_classes):
     """convert the raw feature to a dict by feature id, and corresponding info dict"""
-
-    feature_path = Path(__file__).parent / "features"
-    non_feature_files = ["__init__", "feature_class"]
 
     features_info = {}  # collect features info keyed by feature ids
     all_features = {}  # collect feature values, keyed by feature ids
 
     current_feature_id = 0
-    for f_name in feature_path.glob("*.py"):
-        feature_name = f_name.stem
-        if feature_name not in non_feature_files:
 
-            feature_class = _load_feature_class(feature_name)
-            feature_class_info = feature_class.get_info()
+    for feature_class in list_feature_classes:
+        feature_inst = feature_class()
 
-            for feature in all_features_raw[0][feature_class.shortname]:
-                #features_info[current_feature_id] = feature_class_info.copy()
-                #features_info[current_feature_id]["feature"] = feature
-                features_info[current_feature_id] = feature_class.get_feature_info(feature)
+        for feature in all_features_raw[0][feature_inst.shortname]:
+            features_info[current_feature_id] = feature_inst.get_feature_info(feature)
 
+            all_features[current_feature_id] = []
+            for i, _ in enumerate(all_features_raw):
+                all_features[current_feature_id].append(
+                    all_features_raw[i][feature_inst.shortname][feature]
+                )
 
-                all_features[current_feature_id] = []
-                for i, _ in enumerate(all_features_raw):
-                    all_features[current_feature_id].append(
-                        all_features_raw[i][feature_class.shortname][feature]
-                    )
-
-                current_feature_id += 1
+            current_feature_id += 1
 
     return all_features, features_info
 
@@ -142,3 +148,4 @@ def extract_feature_matrix(all_features):
     feature_matrix = np.array([all_features[feature_id] for feature_id in selected_ids])
 
     return feature_matrix, selected_ids
+

--- a/hcga/features/feature_class.py
+++ b/hcga/features/feature_class.py
@@ -57,16 +57,15 @@ class FeatureClass():
         """main feature extraction function"""
         self.add_feature('test', 0., 'Test feature for the base feature class')
 
-    def update_features(self, all_features, mode):
+    def update_features(self, all_features):
         """update the feature dictionary if correct mode provided"""
         if self.graph is None:
             raise Exception('No graph provided to compute some features.')
         if self.__class__.shortname == 'TP' and self.__class__.__name__ != 'FeatureClass':
             raise Exception('Shortname not set for feature class {}'.format(self.__class__.__name__))
 
-        if mode in self.__class__.modes:
-            self.compute_features()
-            if self.__class__.normalize_features:
-                normalize_features(self)
-            all_features[self.__class__.shortname] = self.features
+        self.compute_features()
+        if self.__class__.normalize_features:
+            normalize_features(self)
+        all_features[self.__class__.shortname] = self.features
 


### PR DESCRIPTION
I fixed the incompatibility of the feature class class variables with multiprocessing. 

The new function `_get_list_feature_classes` creates a list of feature classes (not instances) that correspond to the given mode. For each of those classes, the function `update_features` is run once over a trivial graph (currently a fully connected 3-nodes graph) to make sure all the feature descriptions are created. 