### PR TITLE
Streamlining command file arguments

### DIFF
--- a/hcga/feature_analysis.py
+++ b/hcga/feature_analysis.py
@@ -45,6 +45,7 @@ def analysis(
             )
         else:
             print("To implement!")
+            return None, None, None
 
         return X, testing_accuracy, top_features
 

--- a/hcga/feature_extraction.py
+++ b/hcga/feature_extraction.py
@@ -22,7 +22,9 @@ def extract(
 ):
     """main function to extract features"""
 
-    feat_classes = get_list_feature_classes(mode, normalize_features=normalize_features)
+    feat_classes = get_list_feature_classes(
+            mode, normalize_features=normalize_features,
+            statistics_level=statistics_level)
     if with_runtimes:
         print(
             "WARNING: Runtime option enable, we will only use 10 graphs and one worker to estimate",
@@ -75,7 +77,8 @@ def _load_feature_class(feature_name):
     return getattr(feature_module, feature_module.featureclass_name)
 
 
-def get_list_feature_classes(mode="fast", normalize_features=False):
+def get_list_feature_classes(mode="fast", normalize_features=False,
+        statistics_level='basic'):
     """Generates and returns the list of feature classes to compute for a given mode"""
     feature_path = Path(__file__).parent / "features"
     non_feature_files = ["__init__", "feature_class"]
@@ -91,7 +94,8 @@ def get_list_feature_classes(mode="fast", normalize_features=False):
                 list_feature_classes.append(feature_class)
                 # runs once update_feature with trivial graph to create class variables
                 feature_class(trivial_graph).update_features(
-                    {}, normalize_features=normalize_features
+                    {}, normalize_features=normalize_features,
+                    statistics_level=statistics_level,
                 )
     return list_feature_classes
 

--- a/hcga/features/feature_class.py
+++ b/hcga/features/feature_class.py
@@ -160,6 +160,9 @@ class FeatureClass:
 
     def feature_statistics(self, feat_dist, feat_name, feat_desc, feat_interpret):
         """Computes summary statistics of distributions"""
+        if not hasattr(self, "statistics_level"):
+            # if compute_features used directly without update_features
+            self.statistics_level = 'advanced'
 
         self.feature_statistics_basic(feat_dist, feat_name, feat_desc, feat_interpret)
 

--- a/hcga/features/feature_class.py
+++ b/hcga/features/feature_class.py
@@ -3,12 +3,6 @@ import numpy as np
 import scipy.stats as st
 import networkx as nx
 
-def _try(func, feat_dist):
-    try:
-        return func(feat_dist)
-    except:
-        return np.nan
-
 
 class FeatureClass:
     """template class"""
@@ -92,6 +86,8 @@ class FeatureClass:
 
         try:
             feature = feature_function(self.graph)
+        except (KeyboardInterrupt, SystemExit):
+            raise
         except:
             # if the feature cannot be compute, fill with np.nan
             feature_trivial = feature_function(self.__class__.trivial_graph)
@@ -324,6 +320,14 @@ class FeatureClass:
             "Bayes confidance interval" + compl_desc,
             feat_interpret - 1,
         )
+
+def _try(func, feat_dist):
+    try:
+        return func(feat_dist)
+    except (KeyboardInterrupt, SystemExit):
+        raise
+    except:
+        return np.nan
 
 
 class InterpretabilityScore:

--- a/hcga/io.py
+++ b/hcga/io.py
@@ -4,6 +4,7 @@ import os
 import pickle
 import csv
 import numpy as np
+from pathlib import Path
 
 
 def _ensure_weights(graphs):
@@ -42,9 +43,9 @@ def save_dataset(graphs, labels, filename, folder="./datasets"):
         pickle.dump([graphs, labels], f)
 
 
-def load_dataset(filename, folder="./datasets"):
+def load_dataset(filename):
     """load a dataset from a pickle"""
-    with open(os.path.join(folder, filename + ".pkl"), "rb") as f:
+    with open(filename, "rb") as f:
         graphs_full, labels = pickle.load(f)
 
     graphs = []
@@ -59,17 +60,17 @@ def load_dataset(filename, folder="./datasets"):
     return graphs
 
 
-def save_features(feature_matrix, feature_info, folder=".", filename="features"):
+def save_features(feature_matrix, feature_info, filename="./features.pkl"):
     """Save the features in a pickle"""
-    if not os.path.exists(folder):
-        os.mkdir(folder)
+    if not Path(filename).parent.is_dir():
+        Path(filename).parent.mkdir()
 
     pickle.dump(
         [feature_matrix, feature_info],
-        open(os.path.join(folder, filename + ".pkl"), "wb"),
+        open(filename, "wb"),
     )
 
 
-def load_features(filename="features", folder="."):
+def load_features(filename="features.pkl"):
     """Save the features in a pickle"""
-    return pickle.load(open(os.path.join(folder, filename + ".pkl"), "rb"))
+    return pickle.load(open(filename, "rb"))

--- a/hcga/testing_features.py
+++ b/hcga/testing_features.py
@@ -10,7 +10,7 @@ import numpy as np
 from hcga.dataset_creation import make_test_dataset
 from hcga.feature_extraction import get_list_feature_classes
 
-test_graphs, test_labels = make_test_dataset(write_to_file=False)
+test_graphs, test_labels = make_test_dataset(write_to_file=False, n_graphs=1)
 test_feature_classes = get_list_feature_classes(mode="all")
 
 


### PR DESCRIPTION
I tried to streamline a bit how input and output are dealt with in the commands so that not so many options are required.

There's also a fix for the catch-all try that made interrupting the program with Ctrl-C impossible.